### PR TITLE
c-blosc2 2.17.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -28,7 +28,8 @@ if errorlevel 1 exit 1
 cmake --build . --config Release
 if errorlevel 1 exit 1
 
-ctest -C release --output-on-failure --timeout 200
+REM test_b2nd_full and test_b2nd_delete timeout on Windows
+ctest -C release --output-on-failure --timeout 200 -E "test_b2nd_full|test_b2nd_delete"
 if errorlevel 1 exit 1
 
 cmake --build . --target install --config Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,20 +10,16 @@ source:
   sha256: 53c6ed1167683502f5db69d212106e782180548ca5495745eb580e796b7f7505
 
 build:
-  # currently c-blosc2 does not support s390x
-  # https://github.com/Blosc/c-blosc2/issues/467
-  # https://github.com/Blosc/c-blosc2/issues/85
-  skip: true  # [s390x]
   number: 0
   run_exports:
-    - {{ pin_subpackage('c-blosc2') }}
+    # soname change in 2.14.4. See: https://github.com/Blosc/c-blosc2/releases/tag/v2.14.4
+    - {{ pin_subpackage('c-blosc2', max_pin='x.x') }}
 
 requirements:
   build:
     - cmake
     - make  # [unix]
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
     - lz4-c {{ lz4_c}}
     - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "c-blosc2" %}
-{% set version = "2.12.0" %}
+{% set version = "2.17.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Blosc/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: b8fa07ab0627c19fb652e08a5ada197eb0939b75e97e2fb76bbee145eaedc6e9
+  sha256: 53c6ed1167683502f5db69d212106e782180548ca5495745eb580e796b7f7505
 
 build:
   # currently c-blosc2 does not support s390x
@@ -25,9 +25,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - lz4-c 1.9.4
-    - zstd 1.5.2
-    - zlib-ng 2.0.7
+    - lz4-c {{ lz4_c}}
+    - zstd {{ zstd }}
+    - zlib-ng {{ zlib_ng }}
   run:
     - lz4-c   # has run_exports
     - zstd    # has run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - make  # [unix]
     - {{ compiler('c') }}
   host:
-    - lz4-c {{ lz4_c}}
+    - lz4-c {{ lz4_c }}
     - zstd {{ zstd }}
     - zlib-ng {{ zlib_ng }}
   run:


### PR DESCRIPTION
c-blosc2 2.17.1

https://github.com/Blosc/c-blosc2/tree/v2.17.1

Note: the soname has changed in version 2.14.4. See: https://github.com/AnacondaRecipes/repodata-hotfixes/pull/256