### PR TITLE
c-blosc2 3.1.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "c-blosc2" %}
-{% set version = "2.22.0" %}
+{% set version = "3.1.2" %}
 
 package:
   name: {{ name }}
@@ -7,19 +7,19 @@ package:
 
 source:
   url: https://github.com/Blosc/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 6c6fe90babfa09bd3c544643d3fc3ea9516f9cbc74e8b3342f0d50416862b76f
+  sha256: b4fbad51de56abf2f4660bd1cb9801bc044662db3ea009ede454b4fd36fd98eb
 
 build:
   number: 0
   run_exports:
-    # soname change in 2.14.4. See: https://github.com/Blosc/c-blosc2/releases/tag/v2.14.4
     - {{ pin_subpackage('c-blosc2', max_pin='x.x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
     - cmake
     - make  # [unix]
-    - {{ compiler('c') }}
   host:
     - lz4-c {{ lz4_c }}
     - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
   host:


### PR DESCRIPTION
c-blosc2 3.1.2 

**Destination channel:** Defaults

### Links

- [PKG-14915]
- dev_url:        https://github.com/Blosc/c-blosc2/tree/v3.1.2
- conda_forge:    https://github.com/conda-forge/c-blosc2-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-14915]: https://anaconda.atlassian.net/browse/PKG-14915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ